### PR TITLE
Add post on Imposter Syndrome research for UMass Boston STEM students

### DIFF
--- a/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
+++ b/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
@@ -20,7 +20,7 @@ Click the link here to the survey:
 This is an anonymous survey for STEM students only, aged 18 and over. Help us learn more—because feeling like an imposter shouldn’t hold you back!
 
 For questions, please contact us at:
-- Amanda Potasznik: amanda.potasznik@umb.edu
-- Jariel Rodriguez: jariel.rodriguez001@umb.edu
 - Melaku Mohammed: melaku.mohammed001@umb.edu
+- Jariel Rodriguez: jariel.rodriguez001@umb.edu
 - Saimon Alam: saimon.alam001@umb.edu
+- Amanda Potasznik: amanda.potasznik@umb.edu

--- a/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
+++ b/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
@@ -5,7 +5,7 @@ title: "Understanding Imposter Syndrome in UMass Boston STEM Students"
 
 Do you ever doubt your abilities despite your achievements?
 
-You’re not alone. Imposter Syndrome—the feeling of self-doubt or unworthiness despite evident success—affects many STEM students. We are three IT/CS students conducting a research project to better understand how Imposter Syndrome impacts students like you at UMass Boston, with guidance from Professor Amanda Potasznik.
+You’re not alone. Imposter Syndrome is the feeling of self-doubt or unworthiness despite evident success—affects many STEM students. We are three IT/CS students conducting a research project to better understand how Imposter Syndrome impacts students like you at UMass Boston, with guidance from Professor Amanda Potasznik.
 
 **Why is this important?**
 

--- a/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
+++ b/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
@@ -5,7 +5,7 @@ title: "Understanding Imposter Syndrome in UMass Boston STEM Students"
 
 Do you ever doubt your abilities despite your achievements?
 
-You’re not alone. Imposter Syndrome is the feeling of self-doubt or unworthiness despite evident success—affects many STEM students. We are three IT/CS students conducting a research project to better understand how Imposter Syndrome impacts students like you at UMass Boston, with guidance from Professor Amanda Potasznik.
+You’re not alone. Imposter Syndrome--the feeling of self-doubt or unworthiness despite evident success—affects many STEM students. We are three IT/CS students conducting a research project to better understand how Imposter Syndrome impacts students like you at UMass Boston, with guidance from Professor Amanda Potasznik.
 
 **Why is this important?**
 

--- a/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
+++ b/WEB/POSTS/research/_posts/2024-09-12-impostersyndrome.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Understanding Imposter Syndrome in UMass Boston STEM Students"
+---
+
+Do you ever doubt your abilities despite your achievements?
+
+You’re not alone. Imposter Syndrome—the feeling of self-doubt or unworthiness despite evident success—affects many STEM students. We are three IT/CS students conducting a research project to better understand how Imposter Syndrome impacts students like you at UMass Boston, with guidance from Professor Amanda Potasznik.
+
+**Why is this important?**
+
+We aim to explore how factors such as gender, race, and academic year influence these feelings among STEM students. Your participation will help us gain valuable insights into these issues.
+
+**Your participation matters!** Take a quick 3-minute survey to contribute to this important research.
+
+Click the link here to the survey:
+
+[https://umassboston.co1.qualtrics.com/jfe/form/SV_byiU18N08wvyMbc](https://umassboston.co1.qualtrics.com/jfe/form/SV_byiU18N08wvyMbc)
+
+This is an anonymous survey for STEM students only, aged 18 and over. Help us learn more—because feeling like an imposter shouldn’t hold you back!
+
+For questions, please contact us at:
+- Amanda Potasznik: amanda.potasznik@umb.edu
+- Jariel Rodriguez: jariel.rodriguez001@umb.edu
+- Melaku Mohammed: melaku.mohammed001@umb.edu
+- Saimon Alam: saimon.alam001@umb.edu


### PR DESCRIPTION
Add post on Imposter Syndrome in UMass Boston STEM students

- Published a new post about Imposter Syndrome and its impact on STEM students at UMass Boston.
- Includes a link to a 3-minute anonymous survey for STEM students aged 18 and over.
